### PR TITLE
Fix check for coordinate sorted bam

### DIFF
--- a/run_varscan
+++ b/run_varscan
@@ -131,7 +131,7 @@ fi
 
 # Check that the bam files are sorted
 issort(){
-  didsort=$(samtools view -H $1 | grep ^@HD | cut -f3)
+  didsort=$(samtools view -H $1 | grep -o 'SO:coordinate')
   if [[ "$didsort" != 'SO:coordinate' ]]; then
     graceful_death "it looks like $1 is not sorted by coordinate, please run samtools sort"
   fi


### PR DESCRIPTION
This is a more flexible way to check the sorting order of a BAM file. 