### PR TITLE
Replace /var/spool/cwl with portable reference

### DIFF
--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -83,5 +83,9 @@ outputs:
   - id: output
     type: stdout
 
-baseCommand: ["-s", "/var/spool/cwl"]
+baseCommand: []
+
+arguments:
+  - prefix: "-s"
+    valueFrom: $(runtime.outdir)
 


### PR DESCRIPTION
`/var/spool/cwl` is not part of the CWL v1.x standards. See https://github.com/common-workflow-language/common-workflow-language/issues/674 for a discussion.